### PR TITLE
 Initial OpenShift functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,33 @@ If you would like to deploy AWX (the open source upstream of Tower) into your cl
       tower_task_image: ansible/awx_task:9.2.0
       tower_web_image: ansible/awx_web:9.2.0
 
+### Ingress Types
+
+Depending on the cluster that you're running on, you may wish to use an `Ingress` to access your tower or you may wish to use a `Route` to access your tower. To toggle between these two options, you can add the following to your Tower custom resource:
+
+    ---
+    spec:
+      ...
+      tower_ingress_type: Route
+
+By default, this is configured to use `Ingress`.
+
+### Privileged Tasks
+
+Depending on the type of tasks that you'll be running, you may find that you need the tower task pod to run as `privileged`. This can open yourself up to a variety of security concerns, so you should be aware (and verify that you have the privileges) to do this if necessary. In order to toggle this feature, you can add the following to your Tower custom resource:
+
+    ---
+    spec:
+      ...
+      tower_task_privileged: true
+
+If you are attempting to do this on an OpenShift cluster, you will need to grant the `tower` ServiceAccount the `privileged` SCC, which can be done with:
+
+    oc adm policy add-scc-to-user privileged -z tower
+
+Again, this is the most relaxed SCC that is provided by OpenShift, so be sure to familiarize yourself with the security concerns that accompany this action.
+
+
 ### Persistent storage for Postgres
 
 If you need to use a specific storage class for Postgres' storage, specify `tower_postgres_storage_class` in your Tower spec:

--- a/deploy/crds/tower_v1alpha1_tower_cr_awx.yaml
+++ b/deploy/crds/tower_v1alpha1_tower_cr_awx.yaml
@@ -5,6 +5,9 @@ metadata:
   name: example-tower
   namespace: example-tower
 spec:
+  tower_ingress_type: ingress
+  tower_task_privileged: false
+
   tower_hostname: example-tower.test
   tower_secret_key: aabbcc
 

--- a/deploy/crds/tower_v1alpha1_tower_cr_tower.yaml
+++ b/deploy/crds/tower_v1alpha1_tower_cr_tower.yaml
@@ -5,6 +5,9 @@ metadata:
   name: example-tower
   namespace: example-tower
 spec:
+  tower_ingress_type: ingress
+  tower_task_privileged: false
+
   tower_hostname: example-tower.test
   tower_secret_key: aabbcc
 

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -13,8 +13,6 @@ rules:
       - '*'
   - apiGroups:
       - ""
-  - apiGroups:
-      - ""
     resources:
       - pods
       - services

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -6,6 +6,14 @@ metadata:
   name: tower-operator
 rules:
   - apiGroups:
+      - route.openshift.io
+    resources:
+      - routes
+    verbs:
+      - '*'
+  - apiGroups:
+      - ""
+  - apiGroups:
       - ""
     resources:
       - pods

--- a/deploy/tower-operator.yaml
+++ b/deploy/tower-operator.yaml
@@ -6,6 +6,12 @@ metadata:
   name: tower-operator
 rules:
   - apiGroups:
+      - route.openshift.io
+    resources:
+      - routes
+    verbs:
+      - '*'
+  - apiGroups:
       - ""
     resources:
       - pods

--- a/roles/tower/defaults/main.yml
+++ b/roles/tower/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-tower_multitenant: false
+tower_task_privileged: false
 tower_ingress_type: ingress
 
 tower_hostname: example-tower.test

--- a/roles/tower/defaults/main.yml
+++ b/roles/tower/defaults/main.yml
@@ -32,3 +32,5 @@ tower_postgres_pass: awxpass
 tower_postgres_image: postgres:10
 tower_postgres_storage_request: 8Gi
 tower_postgres_storage_class: ''
+
+tower_postgres_data_path: '/var/lib/postgresql/data/pgdata'

--- a/roles/tower/defaults/main.yml
+++ b/roles/tower/defaults/main.yml
@@ -1,4 +1,7 @@
 ---
+tower_multitenant: false
+tower_ingress_type: ingress
+
 tower_hostname: example-tower.test
 tower_secret_key: aabbcc
 

--- a/roles/tower/templates/tower_config.yaml.j2
+++ b/roles/tower/templates/tower_config.yaml.j2
@@ -40,7 +40,11 @@ data:
     INTERNAL_API_URL = 'http://127.0.0.1:8052'
     
     # Container environments don't like chroots
+{% if tower_multitenant == true %}
+    AWX_PROOT_ENABLED = True
+{% else %}
     AWX_PROOT_ENABLED = False
+{% endif %}
     
     # Automatically deprovision pods that go offline
     AWX_AUTO_DEPROVISION_INSTANCES = True

--- a/roles/tower/templates/tower_config.yaml.j2
+++ b/roles/tower/templates/tower_config.yaml.j2
@@ -40,11 +40,7 @@ data:
     INTERNAL_API_URL = 'http://127.0.0.1:8052'
     
     # Container environments don't like chroots
-{% if tower_multitenant == true %}
-    AWX_PROOT_ENABLED = True
-{% else %}
     AWX_PROOT_ENABLED = False
-{% endif %}
     
     # Automatically deprovision pods that go offline
     AWX_AUTO_DEPROVISION_INSTANCES = True

--- a/roles/tower/templates/tower_postgres.yaml.j2
+++ b/roles/tower/templates/tower_postgres.yaml.j2
@@ -43,13 +43,15 @@ spec:
                 secretKeyRef:
                   name: '{{ meta.name }}-postgres-pass'
                   key: password
+            - name: PGDATA
+              value: '{{ tower_postgres_data_path }}'
           ports:
             - containerPort: 3306
               name: postgres
           volumeMounts:
             - name: postgres
-              mountPath: /var/lib/postgresql/data
-              subPath: data
+              mountPath: '{{ tower_postgres_data_path | dirname }}'
+              subPath: '{{ tower_postgres_data_path | dirname | basename }}'
   volumeClaimTemplates:
     - metadata:
         name: postgres

--- a/roles/tower/templates/tower_task.yaml.j2
+++ b/roles/tower/templates/tower_task.yaml.j2
@@ -20,8 +20,10 @@ spec:
       containers:
       - image: '{{ tower_task_image }}'
         name: tower-task
+{% if tower_multitenant == true %}
         securityContext:
           privileged: true
+{% endif %}
         command:
           - /usr/bin/launch_awx_task.sh
         envFrom:

--- a/roles/tower/templates/tower_task.yaml.j2
+++ b/roles/tower/templates/tower_task.yaml.j2
@@ -20,7 +20,7 @@ spec:
       containers:
       - image: '{{ tower_task_image }}'
         name: tower-task
-{% if tower_multitenant == true %}
+{% if tower_task_privileged == true %}
         securityContext:
           privileged: true
 {% endif %}

--- a/roles/tower/templates/tower_web.yaml.j2
+++ b/roles/tower/templates/tower_web.yaml.j2
@@ -98,6 +98,7 @@ spec:
     app: tower
 
 # Tower Ingress.
+{% if tower_hostname != '' %}
 ---
 apiVersion: extensions/v1beta1
 kind: Ingress
@@ -113,3 +114,4 @@ spec:
         backend:
           serviceName: '{{ meta.name }}-service'
           servicePort: 80
+{% endif %}

--- a/roles/tower/templates/tower_web.yaml.j2
+++ b/roles/tower/templates/tower_web.yaml.j2
@@ -94,11 +94,12 @@ spec:
   - port: 80
     protocol: TCP
     targetPort: 8052
+    name: http
   selector:
     app: tower
 
 # Tower Ingress.
-{% if tower_hostname != '' %}
+{% if 'ingress' == tower_ingress_type %}
 ---
 apiVersion: extensions/v1beta1
 kind: Ingress
@@ -114,4 +115,24 @@ spec:
         backend:
           serviceName: '{{ meta.name }}-service'
           servicePort: 80
+{% endif %}
+
+{% if 'route' == tower_ingress_type %}
+---
+apiVersion: v1
+kind: Route
+metadata:
+  name: '{{ meta.name }}'
+  namespace: '{{ meta.namespace }}'
+spec:
+  port:
+    targetPort: http
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: edge
+  to:
+    kind: Service
+    name: {{ meta.name }}-service
+    weight: 100
+  wildcardPolicy: None
 {% endif %}


### PR DESCRIPTION
Resolves #15 

This PR makes some small changes that allow for an easy deployment on OpenShift:

In tower role defaults:
- Add `tower_postgres_data_path` and set it to `/var/lib/postgresql/data/pgdata`
- Add `tower_ingress_type` variable to allow specifying either ingress or route. Defaults to ingress to maintain current functionality
- Add `tower_multitenant` variable to allow enabling/disabling bubblewrap functionality (i.e. enabling/disabling ` AWX_PROOT_ENABLED` in settings.py found in the configmap). Older 3.X documents seem to point to disabling this via this variable (https://docs.ansible.com/ansible-tower/3.1.3/html/administration/proot_func_variables.html), but it seems to have dissapeared from the 3.6.3 documentation. May just be an oversight as I still see it in use here. Settings this to false disables bubblewrap and removes the `privileged: true` securityContext from the `task` pod. Setting it to true sets this variable to `TRUE` and then enables this securityContext. Would be good to mention in the README that enabling this would then require adding an SCC in order to run on OpenShift.

In `tower_postgres.yaml.j2`:

- Add `PGDATA` env variable and default it to `tower_postgres_data_path`. 
  - Due to some of the chowning/chmoding that happens, this was causing issues with postgres spinning up. By settings this to a path that is under the mount, it is no longer owned by root and we're able to allow changing of permissions
- Modify volumeMount to utilize different parts of `tower_postgres_data_path`. Now the mountPath is set to the parent directory of this variable (i.e. `/var/lib/postgresql/data`) which had been the default path before and the `subPath` is now set to name of the directory

In `tower_web.yaml.j2`:

- If the `tower_ingress_type` is set to ingress, it will create an ingress object
- If the `tower_ingress_type` is set to route, it will create a route object