### PR TITLE
Change default ingress action to none

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,14 @@ Depending on the cluster that you're running on, you may wish to use an `Ingress
       ...
       tower_ingress_type: Route
 
-By default, this is configured to use `Ingress`.
+OR
+
+    ---
+    spec:
+      ...
+      tower_ingress_type: Ingress
+
+By default, no ingress/route is deployed as the default is set to `none`.
 
 ### Privileged Tasks
 

--- a/deploy/crds/tower_v1beta1_tower_cr_awx.yaml
+++ b/deploy/crds/tower_v1beta1_tower_cr_awx.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: example-tower
 spec:
   deployment_type: awx
-  tower_ingress_type: ingress
+  tower_ingress_type: none
   tower_task_privileged: false
 
   tower_hostname: example-tower.test

--- a/deploy/crds/tower_v1beta1_tower_cr_tower.yaml
+++ b/deploy/crds/tower_v1beta1_tower_cr_tower.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: example-tower
 spec:
   deployment_type: tower
-  tower_ingress_type: route
+  tower_ingress_type: none 
   tower_task_privileged: false
 
   tower_hostname: example-tower.test

--- a/deploy/crds/tower_v1beta1_tower_cr_tower.yaml
+++ b/deploy/crds/tower_v1beta1_tower_cr_tower.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: example-tower
 spec:
   deployment_type: tower
-  tower_ingress_type: none 
+  tower_ingress_type: none
   tower_task_privileged: false
 
   tower_hostname: example-tower.test

--- a/roles/tower/defaults/main.yml
+++ b/roles/tower/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 tower_task_privileged: false
-tower_ingress_type: ingress
+tower_ingress_type: none
 
 tower_hostname: example-tower.test
 tower_secret_key: aabbcc


### PR DESCRIPTION
This allows us to be more explicit about the nature of our ingress/route deployments. By default right now, the `tower_ingress_type` is set to `Ingress` and as an unintended consequence we have the ability to not deploy any ingress objects by setting the value of `tower_ingress_type` to anything that isn't `ingress` or `route`. This PR changes this to be more clear by settings this to none and then has the user explicitly change the ingress type to what they are looking for.

resolves #25 