### PR TITLE
Add missing field to spec in Tower CR example

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Then you can create instances of Tower, for example:
        name: tower
        namespace: ansible-tower
      spec:
+       deployment_type: tower
        tower_hostname: tower.mycompany.com
        tower_secret_key: aabbcc
        


### PR DESCRIPTION
The [tower_v1beta1_tower_crd CRD](https://github.com/geerlingguy/tower-operator/blob/master/deploy/crds/tower_v1beta1_tower_crd.yaml#L33) requires a CR spec of its kind to include a `deployment_type` option that is either `tower` or `awx`.

This change adds the `deployment_type` field to the CR example in the README.

Awesome operator! :)