### PR TITLE
Remove exposed ports for redis and memcached

### DIFF
--- a/roles/tower/templates/tower.yaml.j2
+++ b/roles/tower/templates/tower.yaml.j2
@@ -38,16 +38,12 @@ spec:
           - '/var/run/memcached/memcached.sock'
           - '-a'
           - '0666'
-        ports:
-        - containerPort: 1121
         volumeMounts:
           - name: {{ meta.name }}-memcached-socket
             mountPath: "/var/run/memcached"
       - image: '{{ tower_redis_image }}'
         name: redis
         args: ["redis-server", "/etc/redis.conf"]
-        ports:
-        - containerPort: 6379
         volumeMounts:
           - name: {{ meta.name }}-redis-config
             mountPath: "/etc/redis.conf"

--- a/roles/tower/templates/tower_config.yaml.j2
+++ b/roles/tower/templates/tower_config.yaml.j2
@@ -14,10 +14,6 @@ data:
     DATABASE_HOST='{{ meta.name }}-postgres.{{ meta.namespace }}.svc.cluster.local'
     DATABASE_PORT='5432'
     DATABASE_PASSWORD={{ tower_postgres_pass | quote }}
-    MEMCACHED_HOST='{{ meta.name }}-memcached.{{ meta.namespace }}.svc.cluster.local'
-    MEMCACHED_PORT='11211'
-    REDIS_HOST='{{ meta.name }}-redis.{{ meta.namespace }}.svc.cluster.local'
-    REDIS_PORT='6379'
     AWX_SKIP_MIGRATIONS=true
 
   settings: |


### PR DESCRIPTION
We should remove the unused variables for Redis and memcached.

Also, their respective containers are exposing some ports that are not used because Redis and memcached are communicating via sockets.